### PR TITLE
Read the case where the boolean variable is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,8 @@ function readBoolean (array) {
   if (booleanString !== '0' && booleanString !== '1') {
     throw new Error('Parse error: "' + booleanString + '" is not a boolean number.')
   }
-  var boolean = !!booleanString
-  // console.log('readBoolean', leftText)
-  return boolean
+
+  return booleanString === '1'
 }
 
 function readNull (array) {

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,12 @@ describe('single type cases test', function () {
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('boolean with false', function (done) {
+    var expected = {key: false}
+    var result = unserialize('key|b:0;')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
   it('null', function (done) {
     var expected = {key: null}
     var result = unserialize('key|n;')


### PR DESCRIPTION
Currently, even if the value is 0, it is reading as true.
It must be false when the value of boolean is 0.

> In JavaScript, a truthy value is a value that is considered true when encountered in a Boolean context. All values are truthy unless they are defined as falsy (i.e., except for false, 0, -0, 0n, "", null, undefined, and NaN).

If the string is 1, set it to true otherwise false.

See also
  - https://developer.mozilla.org/en-US/docs/Glossary/Truthy
  - https://developer.mozilla.org/en-US/docs/Glossary/Falsy