### PR TITLE
Add typescript import support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+export = unserializer;
+/**
+ * Unserialize a PHP session string to an object
+ * @param {string} text PHP session string
+ * @returns {} Session object
+ */
+declare function unserializer(text: string): any;

--- a/index.js
+++ b/index.js
@@ -140,6 +140,11 @@ function read (array) {
   return result
 }
 
+/**
+ * Unserialize a PHP session string to an object
+ * @param {string} text PHP session string
+ * @returns {} Session object
+ */
 function unserializer (text) {
   const result = {}
   const array = Array.from(text)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "php-session-unserialize",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3485,6 +3485,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "mocha --covignore .covignore test/",
     "lint": "eslint --fix .",
     "cover": "nyc mocha",
-    "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
+    "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls",
+    "tsc": "tsc"
   },
   "repository": {
     "type": "git",
@@ -48,6 +49,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "mocha": "^9.1.3",
     "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "typescript": "^4.8.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "include": ["index.js"],
+    "compilerOptions": {
+        "allowJs": true,
+        "declaration": true,
+        "emitDeclarationOnly": true
+    }
+}


### PR DESCRIPTION
This PR just adds type annotations so the npm package can be imported into typescript projects.

If the module signatures ever change, the workflow is fairly simple:
* Update the JSDoc comments in `index.js` to reflect the signature changes
* `npm run tsc` to rebuild `index.d.ts`
* Commit